### PR TITLE
Added able track total hits

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -30,6 +30,8 @@ class Builder
 
     protected bool $withAggregations = true;
 
+    protected bool $trackTotalHits = false;
+
     public function __construct(protected Client $client)
     {
     }
@@ -87,12 +89,23 @@ class Builder
             $params['from'] = $this->from;
         }
 
+        if($this->trackTotalHits){
+            $params['track_total_hits'] = true;
+        }
+
         return $this->client->search($params);
     }
 
     public function index(string $searchIndex): static
     {
         $this->searchIndex = $searchIndex;
+
+        return $this;
+    }
+
+    public function trackTotalHits($value = true): static
+    {
+        $this->trackTotalHits = $value;
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -103,7 +103,7 @@ class Builder
         return $this;
     }
 
-    public function trackTotalHits($value = true): static
+    public function trackTotalHits(bool $value = true): static
     {
         $this->trackTotalHits = $value;
 


### PR DESCRIPTION
By default, Elasticsearch does not track the total number of documents by query.
Add the ability to get the exact number of documents.

Property $trackTotalHits = false by default  // The behavior of Elasticsearch itself

How to use:
$builder->track Total Hits();  // if  you need to track total hits

$builder->track Total Hits(false); // if you don't need track total hits
